### PR TITLE
Revert "Bump prism-react-renderer from 1.3.5 to 2.0.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/preset-classic": "2.3.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
-        "prism-react-renderer": "^2.0.5",
+        "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -2430,14 +2430,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "peerDependencies": {
-        "react": ">=0.14.9"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
@@ -2465,14 +2457,6 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "peerDependencies": {
-        "react": ">=0.14.9"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -3338,11 +3322,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
-    },
-    "node_modules/@types/prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -9134,15 +9113,11 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.5.tgz",
-      "integrity": "sha512-VHTC2ZhOImeC3/mu/3TkEuRCa1K+kTCZQeCkwvWzQa01/ahU3dibyxWf3XiPLuO4k/rGjSTea1lEsfza6fMofw==",
-      "dependencies": {
-        "@types/prismjs": "^1.26.0",
-        "clsx": "^1.2.1"
-      },
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
       "peerDependencies": {
-        "react": ">=16.0.0"
+        "react": ">=0.14.9"
       }
     },
     "node_modules/prismjs": {
@@ -14197,14 +14172,6 @@
         "rtlcss": "^3.5.0",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "prism-react-renderer": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-          "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-          "requires": {}
-        }
       }
     },
     "@docusaurus/theme-common": {
@@ -14227,14 +14194,6 @@
         "tslib": "^2.4.0",
         "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "prism-react-renderer": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-          "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-          "requires": {}
-        }
       }
     },
     "@docusaurus/theme-search-algolia": {
@@ -14869,11 +14828,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
-    },
-    "@types/prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -19034,13 +18988,10 @@
       "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
     "prism-react-renderer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.5.tgz",
-      "integrity": "sha512-VHTC2ZhOImeC3/mu/3TkEuRCa1K+kTCZQeCkwvWzQa01/ahU3dibyxWf3XiPLuO4k/rGjSTea1lEsfza6fMofw==",
-      "requires": {
-        "@types/prismjs": "^1.26.0",
-        "clsx": "^1.2.1"
-      }
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
+      "requires": {}
     },
     "prismjs": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/preset-classic": "2.3.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
-    "prism-react-renderer": "^2.0.5",
+    "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
Reverts errordeck/docs#11